### PR TITLE
fix for detect_encoding returning a hash without :encoding key

### DIFF
--- a/lib/charlock_holmes/string.rb
+++ b/lib/charlock_holmes/string.rb
@@ -24,7 +24,7 @@ class String
     # Returns: self
     def detect_encoding!(hint_enc=nil)
       if detected = self.detect_encoding(hint_enc)
-        self.force_encoding detected[:encoding]
+        self.force_encoding(detected[:encoding]) if detected[:encoding]
       end
       self
     end


### PR DESCRIPTION
this can happen for binary strings, or strings that appear as binary:

```
ruby-1.9.3-p125-perf :017 > "BEGIN:VCARD\n".detect_encoding
 => {:type=>:binary, :confidence=>100} 
```
