### PR TITLE
Fix issue #8 (lib64 path for libmagic.a)

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -63,7 +63,9 @@ Dir.chdir("#{CWD}/src") do
   end
 end
 
-FileUtils.cp "#{CWD}/dst/lib/libmagic.a", "#{CWD}/libmagic_ext.a"
+['foo'].pack('p').size == 8 ? lib_dir = 'lib64' : lib_dir = 'lib'
+
+FileUtils.cp "#{CWD}/dst/#{lib_dir}/libmagic.a", "#{CWD}/libmagic_ext.a"
 
 $INCFLAGS[0,0] = " -I#{CWD}/dst/include "
 $LDFLAGS << " -L#{CWD} "


### PR DESCRIPTION
Could someone please check this in? This issue is still present in openSUSE 12.2 x86_64 / Ruby 1.9.3.
