### PR TITLE
fix lib64 library path (issue #8)

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -51,6 +51,7 @@ end
 
 src = File.basename('file-5.08.tar.gz')
 dir = File.basename(src, '.tar.gz')
+libdir = 'lib'
 
 Dir.chdir("#{CWD}/src") do
   FileUtils.rm_rf(dir) if File.exists?(dir)
@@ -60,10 +61,12 @@ Dir.chdir("#{CWD}/src") do
     sys("./configure --prefix=#{CWD}/dst/ --disable-shared --enable-static --with-pic")
     sys("make -C src install")
     sys("make -C magic install")
+    # this should evaluate to either 'lib' or 'lib64'
+    libdir = `grep ^libdir config.log`.strip().split("'")[1].split('/')[-1]
   end
 end
 
-FileUtils.cp "#{CWD}/dst/lib/libmagic.a", "#{CWD}/libmagic_ext.a"
+FileUtils.cp "#{CWD}/dst/#{libdir}/libmagic.a", "#{CWD}/libmagic_ext.a"
 
 $INCFLAGS[0,0] = " -I#{CWD}/dst/include "
 $LDFLAGS << " -L#{CWD} "


### PR DESCRIPTION
On SUSE (and some other distros), libraries on 64-bit platforms get installed
to ${exec_prefix}/lib64 rather than .../lib.  Detect the correct path by
parsing config.log.

Tested to build successfully on the following:
- openSUSE 12.2 x86_64
- openSUSE 12.1 i586
- CentOS 6.3 x86_64
- CentOS 6.3 i386
- Ubuntu 12.04 x86_64
- Ubuntu 12.04 i386
- OS X 10.8 x86_64
