### PR TITLE
Fix detection for TCL (and possibly other file types).

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -54,7 +54,7 @@ static int detect_binary_content(charlock_detector_t *detector, VALUE rb_str) {
 	binary_result = magic_buffer(detector->magic, RSTRING_PTR(rb_str), RSTRING_LEN(rb_str));
 
 	if (binary_result) {
-		if (!strstr(binary_result, "text"))
+		if (strstr(binary_result, "charset=binary"))
 			return 1;
 	} else {
 		rb_raise(rb_eStandardError, "%s", magic_error(detector->magic));
@@ -274,7 +274,7 @@ static VALUE rb_encdec__alloc(VALUE klass)
 		rb_raise(rb_eStandardError, "%s", u_errorName(status));
 	}
 
-	detector->magic = magic_open(0);
+	detector->magic = magic_open(MAGIC_MIME);
 	if (detector->magic == NULL) {
 		rb_raise(rb_eStandardError, "%s", magic_error(detector->magic));
 	}

--- a/spec/encoding_detector_spec.rb
+++ b/spec/encoding_detector_spec.rb
@@ -98,6 +98,7 @@ describe CharlockHolmes::EncodingDetector do
       ['TwigExtensionsDate.es.yml', 'UTF-8',      :text],
       ['AnsiGraph.psm1',            'UTF-16LE',   :text],
       ['laholator.py',              'UTF-8',      :text],
+      ['test.tcl',                  'ISO-8859-1', :text],
       ['hello_world',               nil,          :binary]
     ]
 

--- a/spec/fixtures/test.tcl
+++ b/spec/fixtures/test.tcl
@@ -1,0 +1,1 @@
+package require something


### PR DESCRIPTION
This changes how binary files are detected.

Previously, libmagic was used to get the magic message for a file's
contents and check if the message contained the substring "text". This
worked fine for most file types, but some magic messages did not
contain this substring (e.g. for TCL files, it was only `Tcl script,`)
and they'd incorrectly be detected as binary (see
brianmario/charlock_holmes#13).

This commit sets the magic `MAGIC_MIME` flag so that `magic_buffer` instead returns the
mime type, and we now check if that mime type contains the substring
`charset=binary`.
