### PR TITLE
make it so mac installs don't take 5+ minutes every time you run bundle

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -46,6 +46,7 @@ unless have_library 'icui18n' and have_library 'icudata' and have_library 'icutu
     Dir.chdir(File.join(dir, 'source')) do
       sys("LDFLAGS= CXXFLAGS=\"-O2 -fPIC\" CFLAGS=\"-O2 -fPIC\" ./configure --prefix=#{CWD}/dst/ --disable-tests --disable-samples --disable-icuio --disable-extras --disable-layout --enable-static --disable-shared")
       sys("make install")
+      sys("make clean")
     end
   end
 
@@ -79,10 +80,13 @@ Dir.chdir("#{CWD}/src") do
     sys("patch -p0 < ../file-soft-check.patch")
     sys("make -C src install")
     sys("make -C magic install")
+    sys("make -C src clean")
+    sys("make -C magic clean")
   end
 end
 
 FileUtils.cp "#{CWD}/dst/lib/libmagic.a", "#{CWD}/libmagic_ext.a"
+FileUtils.rm_rf("#{CWD}/src")
 
 $INCFLAGS[0,0] = " -I#{CWD}/dst/include "
 $LDFLAGS << " -L#{CWD} "

--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -1,4 +1,5 @@
 require 'mkmf'
+require 'fileutils'
 
 CWD = File.expand_path(File.dirname(__FILE__))
 def sys(cmd)
@@ -35,8 +36,18 @@ if !have_library 'icui18n'
   end
 end
 
+icu_version = "49_1_2"
+
+# If the ICU version is changed 
+bundled_icu_flag = "#{CWD}/bundled_icu_flag_#{icu_version}"
+
+if File.exists?(bundled_icu_flag)
+  $INCFLAGS << " -I#{CWD}/dst/include "
+  $LDFLAGS  << " -L#{CWD}/dst/lib"
+end
+
 unless have_library 'icui18n' and have_library 'icudata' and have_library 'icutu' and have_library 'icuuc' and have_header 'unicode/ucnv.h'
-  src = File.basename('icu4c-49_1_2-src.tgz')
+  src = File.basename("icu4c-#{icu_version}-src.tgz")
   dir = File.basename('icu')
 
   Dir.chdir("#{CWD}/src") do
@@ -51,6 +62,8 @@ unless have_library 'icui18n' and have_library 'icudata' and have_library 'icutu
   end
 
   dir_config 'icu'
+
+  FileUtils.touch(bundled_icu_flag)
 
   $INCFLAGS << " -I#{CWD}/dst/include "
   $LDFLAGS  << " -L#{CWD}/dst/lib"
@@ -68,30 +81,40 @@ end
 # libmagic dependency
 #
 
-src = File.basename('file-5.08.tar.gz')
-dir = File.basename(src, '.tar.gz')
+libmagic_version = "5.08"
 
-Dir.chdir("#{CWD}/src") do
-  FileUtils.rm_rf(dir) if File.exists?(dir)
+bundled_libmagic_flag = "#{CWD}/bundled_libmagic_flag_#{icu_version}_#{libmagic_version}"
 
-  sys("tar zxvf #{src}")
-  Dir.chdir(dir) do
-    sys("./configure --prefix=#{CWD}/dst/ --disable-shared --enable-static --with-pic")
-    sys("patch -p0 < ../file-soft-check.patch")
-    sys("make -C src install")
-    sys("make -C magic install")
-    sys("make -C src clean")
-    sys("make -C magic clean")
+if File.exists?(bundled_libmagic_flag)
+  $LDFLAGS << " -L#{CWD} "
+else
+  src = File.basename("file-#{libmagic_version}.tar.gz")
+  dir = File.basename(src, '.tar.gz')
+
+  Dir.chdir("#{CWD}/src") do
+    FileUtils.rm_rf(dir) if File.exists?(dir)
+
+    sys("tar zxvf #{src}")
+    Dir.chdir(dir) do
+      sys("./configure --prefix=#{CWD}/dst/ --disable-shared --enable-static --with-pic")
+      sys("patch -p0 < ../file-soft-check.patch")
+      sys("make -C src install")
+      sys("make -C magic install")
+      sys("make -C src clean")
+      sys("make -C magic clean")
+    end
   end
+
+  FileUtils.cp "#{CWD}/dst/lib/libmagic.a", "#{CWD}/libmagic_ext.a"
+  FileUtils.rm_rf("#{CWD}/src/icu")
+  FileUtils.rm_rf("#{CWD}/src/file-5.08")
+
+  $INCFLAGS[0,0] = " -I#{CWD}/dst/include "
+  $LDFLAGS << " -L#{CWD} "
 end
 
-FileUtils.cp "#{CWD}/dst/lib/libmagic.a", "#{CWD}/libmagic_ext.a"
-FileUtils.rm_rf("#{CWD}/src")
-
-$INCFLAGS[0,0] = " -I#{CWD}/dst/include "
-$LDFLAGS << " -L#{CWD} "
-
 dir_config 'magic'
+
 unless have_library 'magic_ext' and have_header 'magic.h'
   STDERR.puts "\n\n"
   STDERR.puts "***************************************************************************************"


### PR DESCRIPTION
I pulled in changes from master that look for homebrew-installed icu to limit bundle time when developing locally on a mac. I think this is a great change for anyone developing on a mac and deploying on Heroku.

I've also added changes that run make clean for all the precursor packages (libmagic, icu) and then further removes the src directory. This takes the gem size down SIGNIFICANTLY, from around 600mb unpacked to under 200mb. This change took our Heroku slug size from ~125mb to ~65mb.
