### PR TITLE
use HTTPS URLs for the project

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Brian Lopez - http://github.com/brianmario
+Copyright (c) 2011 Brian Lopez - https://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/charlock_holmes.gemspec
+++ b/charlock_holmes.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = %q{seniorlopez@gmail.com}
   s.extensions = ["ext/charlock_holmes/extconf.rb"]
   s.files = `git ls-files`.split("\n")
-  s.homepage = %q{http://github.com/brianmario/charlock_holmes}
+  s.homepage = %q{https://github.com/brianmario/charlock_holmes}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.4.2}

--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -4,7 +4,7 @@ CWD = File.expand_path(File.dirname(__FILE__))
 def sys(cmd)
   puts "  -- #{cmd}"
   unless ret = xsystem(cmd)
-    raise "#{cmd} failed, please report issue on http://github.com/brianmario/charlock_holmes"
+    raise "#{cmd} failed, please report issue on https://github.com/brianmario/charlock_holmes"
   end
   ret
 end


### PR DESCRIPTION
GitHub supports HTTPS. This pull request switches the URLs in the documentation and gemspec to use the secured URLs.
