### PR TITLE
tests: switch to minitest 5

### DIFF
--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require File.expand_path("../helper", __FILE__)
 
-class ConverterTest < MiniTest::Unit::TestCase
+class ConverterTest < MiniTest::Test
   def test_convert_ascii_from_iso859_1_to_utf16_and_back
     input = 'test'
 

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require File.expand_path("../helper", __FILE__)
 
-class EncodingDetectorTest < MiniTest::Unit::TestCase
+class EncodingDetectorTest < MiniTest::Test
   def setup
     @detector = CharlockHolmes::EncodingDetector.new
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,13 @@ require 'charlock_holmes'
 # bring in minitest
 require 'minitest/autorun'
 
+if Minitest.const_defined?('Test')
+  # We're on Minitest 5+. Nothing to do here.
+else
+  # Minitest 4 doesn't have Minitest::Test yet.
+  Minitest::Test = MiniTest::Unit::TestCase
+end
+
 # put lib and test dirs directly on load path
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift File.expand_path('..', __FILE__)

--- a/test/string_methods_test.rb
+++ b/test/string_methods_test.rb
@@ -1,7 +1,7 @@
 require File.expand_path("../helper", __FILE__)
 require 'charlock_holmes/string'
 
-class StringMethodsTest < MiniTest::Unit::TestCase
+class StringMethodsTest < MiniTest::Test
   def test_adds_detect_encoding_method
     str = 'test'
     str.respond_to? :detect_encoding

--- a/test/transliterator_test.rb
+++ b/test/transliterator_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require File.expand_path("../helper", __FILE__)
 
-class TransliteratorTest < MiniTest::Unit::TestCase
+class TransliteratorTest < MiniTest::Test
   DONT_CONVERT = [
     "Vitrum edere possum; mihi non nocet.", # Latin
     "Je puis mangier del voirre. Ne me nuit.", # Old French


### PR DESCRIPTION
Adjust the test suite to support Minitest 5's syntax.

Minitest versions 4 and below do not support the newer Minitest::Test class that arrived in version 5. For that case, use the MiniTest::Unit::TestCase class as a fallback.
