### PR TITLE
enable `detect_encoding!` for ruby 2

### DIFF
--- a/lib/charlock_holmes/string.rb
+++ b/lib/charlock_holmes/string.rb
@@ -19,7 +19,7 @@ class String
     detector.detect_all(self, hint_enc)
   end
 
-  if RUBY_VERSION =~ /^(1.9|2)/
+  if method_defined? :force_encoding
     # Attempt to detect the encoding of this string
     # then set the encoding to what was detected ala `force_encoding`
     #


### PR DESCRIPTION
`detect_encoding!` only works with 1.9, this pull enables it for ruby 2 as well
