### PR TITLE
Add some windows-* aliases to supported encodings list for detection

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -299,6 +299,12 @@ static VALUE rb_get_supported_encodings(VALUE klass)
 		rb_encoding_list = rb_ary_new();
 		enc_count = uenum_count(encoding_list, &status);
 
+		rb_ary_push(rb_encoding_list, charlock_new_str2("windows-1250"));
+		rb_ary_push(rb_encoding_list, charlock_new_str2("windows-1252"));
+		rb_ary_push(rb_encoding_list, charlock_new_str2("windows-1253"));
+		rb_ary_push(rb_encoding_list, charlock_new_str2("windows-1254"));
+		rb_ary_push(rb_encoding_list, charlock_new_str2("windows-1255"));
+
 		for(i=0; i < enc_count; i++) {
 			enc_name = uenum_next(encoding_list, &enc_name_len, &status);
 			rb_ary_push(rb_encoding_list, charlock_new_str(enc_name, enc_name_len));

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -87,6 +87,11 @@ class EncodingDetectorTest < MiniTest::Test
 
     assert supported_encodings.is_a?(Array)
     assert supported_encodings.include? 'UTF-8'
+    assert supported_encodings.include? 'windows-1250'
+    assert supported_encodings.include? 'windows-1252'
+    assert supported_encodings.include? 'windows-1253'
+    assert supported_encodings.include? 'windows-1254'
+    assert supported_encodings.include? 'windows-1255'
   end
 
   def test_returns_a_ruby_compatible_encoding_name


### PR DESCRIPTION
Why?

windows-1252 is an alias for ISO-8859-1 but not returned as an entry in the supported encodings list for the detection API. This means the lookup table we build for Ruby-compatible encoding names won't include it and lookups for that encoding name will fail.

From the ICU documentation:

Note: Multiple different charset encodings in a same family may use a single shared name in this implementation. For example, this method returns an array including "ISO-8859-1" (ISO Latin 1), but not including "windows-1252" (Windows Latin 1). However, actual detection result could be "windows-1252" when the input data matches Latin 1 code points with any points only available in "windows-1252".
