### PR TITLE
Add UTF-16 to expected default encoding list

### DIFF
--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -24,7 +24,7 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_class_level_detect_all_method_accepts_encoding_hint
@@ -33,7 +33,7 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_has_detect_method
@@ -54,7 +54,7 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_detect_all_accepts_encoding_hint
@@ -63,7 +63,7 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_strip_tags_flag

--- a/test/string_methods_test.rb
+++ b/test/string_methods_test.rb
@@ -26,7 +26,7 @@ class StringMethodsTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_detect_encodings_accepts_encoding_hint_param
@@ -37,7 +37,7 @@ class StringMethodsTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-16BE', 'UTF-16LE', 'UTF-8'], encoding_list
   end
 
   def test_returns_a_ruby_compatible_encoding_name


### PR DESCRIPTION
Hey @brianmario, it looks like these tests are failing on master too. You fixed them in a branch commit, 43037a6ded58946861bd25e771fe53465c05a270, but we should probably just merge the fix in to master first. I'm not sure what change triggered a output differences. Maybe since I'm using icu4c 54.1 locally now?
