### PR TITLE
Silence unused function warnings

### DIFF
--- a/ext/charlock_holmes/common.h
+++ b/ext/charlock_holmes/common.h
@@ -11,7 +11,7 @@
 #include <ruby/encoding.h>
 #endif
 
-static VALUE charlock_new_enc_str(const char *str, size_t len, void *encoding)
+static inline VALUE charlock_new_enc_str(const char *str, size_t len, void *encoding)
 {
 #ifdef HAVE_RUBY_ENCODING_H
 	return rb_external_str_new_with_enc(str, len, (rb_encoding *)encoding);
@@ -20,7 +20,7 @@ static VALUE charlock_new_enc_str(const char *str, size_t len, void *encoding)
 #endif
 }
 
-static VALUE charlock_new_str(const char *str, size_t len)
+static inline VALUE charlock_new_str(const char *str, size_t len)
 {
 #ifdef HAVE_RUBY_ENCODING_H
 	return rb_external_str_new_with_enc(str, len, rb_utf8_encoding());
@@ -29,7 +29,7 @@ static VALUE charlock_new_str(const char *str, size_t len)
 #endif
 }
 
-static VALUE charlock_new_str2(const char *str)
+static inline VALUE charlock_new_str2(const char *str)
 {
 #ifdef HAVE_RUBY_ENCODING_H
 	return rb_external_str_new_with_enc(str, strlen(str), rb_utf8_encoding());


### PR DESCRIPTION
Any difference ideas other than defining them in their own object file?

```
make
compiling ../../../../ext/charlock_holmes/converter.c
In file included from ../../../../ext/charlock_holmes/converter.c:2:
../../../../ext/charlock_holmes/common.h:23:14: warning: unused function 'charlock_new_str' [-Wunused-function]
static VALUE charlock_new_str(const char *str, size_t len)
             ^
../../../../ext/charlock_holmes/common.h:32:14: warning: unused function 'charlock_new_str2' [-Wunused-function]
static VALUE charlock_new_str2(const char *str)
             ^
2 warnings generated.
compiling ../../../../ext/charlock_holmes/encoding_detector.c
In file included from ../../../../ext/charlock_holmes/encoding_detector.c:2:
../../../../ext/charlock_holmes/common.h:14:14: warning: unused function 'charlock_new_enc_str' [-Wunused-function]
static VALUE charlock_new_enc_str(const char *str, size_t len, void *encoding)
             ^
1 warning generated.
compiling ../../../../ext/charlock_holmes/ext.c
In file included from ../../../../ext/charlock_holmes/ext.c:1:
../../../../ext/charlock_holmes/common.h:14:14: warning: unused function 'charlock_new_enc_str' [-Wunused-function]
static VALUE charlock_new_enc_str(const char *str, size_t len, void *encoding)
             ^
../../../../ext/charlock_holmes/common.h:23:14: warning: unused function 'charlock_new_str' [-Wunused-function]
static VALUE charlock_new_str(const char *str, size_t len)
             ^
../../../../ext/charlock_holmes/common.h:32:14: warning: unused function 'charlock_new_str2' [-Wunused-function]
static VALUE charlock_new_str2(const char *str)
             ^
3 warnings generated.
```
