### PR TITLE
Add is_binary? method to encoding detector api

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -130,6 +130,24 @@ static int detect_binary_content(VALUE self, VALUE rb_str) {
 }
 
 /*
+ * call-seq: true/false = EncodingDetector.is_binary? str
+ *
+ * Attempt to detect the encoding of this string
+ *
+ * str      - a String, what you want to perform the binary check on
+ *
+ * Returns: true or false
+ */
+static VALUE rb_encdec_is_binary(VALUE self, VALUE str)
+{
+	// first lets see if this is binary content
+	if (detect_binary_content(self, str))
+		return Qtrue;
+	else
+		return Qfalse;
+}
+
+/*
  * call-seq: detection_hash = EncodingDetector.detect str[, hint_enc]
  *
  * Attempt to detect the encoding of this string
@@ -350,6 +368,7 @@ void _init_charlock_encoding_detector()
 {
 	rb_cEncodingDetector = rb_define_class_under(rb_mCharlockHolmes, "EncodingDetector", rb_cObject);
 	rb_define_alloc_func(rb_cEncodingDetector, rb_encdec__alloc);
+	rb_define_method(rb_cEncodingDetector, "is_binary?", rb_encdec_is_binary, 1);
 	rb_define_method(rb_cEncodingDetector, "detect", rb_encdec_detect, -1);
 	rb_define_method(rb_cEncodingDetector, "detect_all", rb_encdec_detect_all, -1);
 	rb_define_method(rb_cEncodingDetector, "strip_tags", rb_get_strip_tags, 0);

--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -140,7 +140,6 @@ static int detect_binary_content(VALUE self, VALUE rb_str) {
  */
 static VALUE rb_encdec_is_binary(VALUE self, VALUE str)
 {
-	// first lets see if this is binary content
 	if (detect_binary_content(self, str))
 		return Qtrue;
 	else

--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -132,7 +132,7 @@ static int detect_binary_content(VALUE self, VALUE rb_str) {
 /*
  * call-seq: true/false = EncodingDetector.is_binary? str
  *
- * Attempt to detect the encoding of this string
+ * Attempt to detect if a string is binary or text
  *
  * str      - a String, what you want to perform the binary check on
  *

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -105,6 +105,17 @@ class EncodingDetectorTest < MiniTest::Test
     assert_equal 'binary', detected[:ruby_encoding]
   end
 
+  def test_is_binary
+    png = fixture('octocat.png').read
+    assert @detector.is_binary?(png)
+
+    utf16 = fixture('AnsiGraph.psm1').read
+    refute @detector.is_binary?(utf16)
+
+    utf8 = fixture('core.rkt').read
+    refute @detector.is_binary?(utf8)
+  end
+
   MAPPING = [
     ['repl2.cljs',                'ISO-8859-1', :text],
     ['cl-messagepack.lisp',       'ISO-8859-1', :text],


### PR DESCRIPTION
This was already split out in it's own function but wasn't surfaced in the Ruby API. This can be useful to perform a fast binary check that's a little smarter than just checking for NULL bytes, without it falling back to performing encoding detection.

This change also makes me wonder if we should split out a method for *just* performing encoding detection (without the binary check). That way if you wanted to use this new `is_binary?` method, you could perform encoding detection later without also have it re-perform the binary check.

/cc @aroben @josh @adelcambre