### PR TITLE
Include icui18n only once

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -24,8 +24,10 @@ end
 dir_config 'icu'
 
 rubyopt = ENV.delete("RUBYOPT")
+icui18n_present = have_library('icui18n')
+
 # detect homebrew installs
-if !have_library 'icui18n'
+if !icui18n_present
   base = if !`which brew`.empty?
     `brew --prefix`.strip
   elsif File.exists?("/usr/local/Cellar/icu4c")
@@ -38,7 +40,7 @@ if !have_library 'icui18n'
   end
 end
 
-unless have_library 'icui18n' and have_header 'unicode/ucnv.h'
+unless icui18n_present and have_header 'unicode/ucnv.h'
   STDERR.puts "\n\n"
   STDERR.puts "***************************************************************************************"
   STDERR.puts "*********** icu required (brew install icu4c or apt-get install libicu-dev) ***********"


### PR DESCRIPTION
When I run `ruby extconf.rb` I'm getting the following output:

```
checking for main() in -licui18n... yes
checking for main() in -licui18n... yes
checking for unicode/ucnv.h... yes
checking for main() in -lz... yes
checking for main() in -licuuc... yes
checking for main() in -licudata... yes
creating Makefile
```

So, it checks for `main() in -licui18n` twice, which results with the following entry in the generated `Makefile`:

```
LIBS =  -licudata -licuuc -lz -licui18n -licui18n  -lpthread -lgmp -ldl -lcrypt -lm   -lc
```

While this is not harmful (at least I don't know of any harm) on my machine, it has bee suggested (https://github.com/brianmario/charlock_holmes/issues/32#issuecomment-15891091) that it might cause some other problems.

Anyway, it's always good to have the flags passed only once and this PR fixes it.
