### PR TITLE
return `ruby_encoding` & `encoding` fields for binary data

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -53,6 +53,8 @@ static VALUE rb_encdec_binarymatch() {
 	rb_match = rb_hash_new();
 
 	rb_hash_aset(rb_match, ID2SYM(rb_intern("type")), ID2SYM(rb_intern("binary")));
+	rb_hash_aset(rb_match, ID2SYM(rb_intern("encoding")), charlock_new_str2("BINARY"));
+	rb_hash_aset(rb_match, ID2SYM(rb_intern("ruby_encoding")), charlock_new_str2("ASCII-8BIT"));
 	rb_hash_aset(rb_match, ID2SYM(rb_intern("confidence")), INT2NUM(100));
 
 	return rb_match;

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -103,6 +103,10 @@ class EncodingDetectorTest < MiniTest::Test
     detected = @detector.detect not_compat_txt
     assert_equal 'ISO-2022-KR', detected[:encoding]
     assert_equal 'binary', detected[:ruby_encoding]
+
+    detected = @detector.detect "\0\0"
+    assert_equal 'BINARY', detected[:encoding]
+    assert_equal 'ASCII-8BIT', detected[:ruby_encoding]
   end
 
   def test_is_binary
@@ -128,13 +132,13 @@ class EncodingDetectorTest < MiniTest::Test
     ['utf16be.html',              'UTF-16BE',   :text],
     ['utf32le.html',              'UTF-32LE',   :text],
     ['utf32be.html',              'UTF-32BE',   :text],
-    ['hello_world',               nil,          :binary],
-    ['octocat.png',               nil,          :binary],
-    ['octocat.jpg',               nil,          :binary],
-    ['octocat.psd',               nil,          :binary],
-    ['octocat.gif',               nil,          :binary],
-    ['octocat.ai',                nil,          :binary],
-    ['foo.pdf',                   nil,          :binary],
+    ['hello_world',               'BINARY',     :binary],
+    ['octocat.png',               'BINARY',     :binary],
+    ['octocat.jpg',               'BINARY',     :binary],
+    ['octocat.psd',               'BINARY',     :binary],
+    ['octocat.gif',               'BINARY',     :binary],
+    ['octocat.ai',                'BINARY',     :binary],
+    ['foo.pdf',                   'BINARY',     :binary],
   ]
 
   def test_detection_works_as_expected


### PR DESCRIPTION
Currently `detect` doesn't return `:encoding` & `:ruby_encoding` fields when data type is binary.

Current version:

```
> CharlockHolmes::EncodingDetector.detect("\0")
=> {:type=>:binary, :confidence=>100}
> CharlockHolmes::EncodingDetector.detect("a")
=> {:type=>:text, :encoding=>"UTF-8", :ruby_encoding=>"UTF-8", :confidence=>15}
```

Updated:

```
> CharlockHolmes::EncodingDetector.detect("\0")
{:type=>:binary, :encoding=>"BINARY", :ruby_encoding=>"ASCII-8BIT", :confidence=>100}
```

`BINARY` & `ASCII-8BIT` are aliases.