### PR TITLE
Build ICU 59.1 with C++ 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install libicu-dev
+dist: trusty
+addons:
+  apt:
+    packages:
+    - libicu-dev
 language: ruby
 rvm:
+  - 2.4
   - 2.2
   - 2.1
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 language: ruby
 rvm:
   - 2.4
+  - 2.3
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3

--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -50,6 +50,7 @@ have_library 'z' or abort 'libz missing'
 have_library 'icuuc' or abort 'libicuuc missing'
 have_library 'icudata' or abort 'libicudata missing'
 
+$CXXFLAGS << ' -std=c++11'
 $CFLAGS << ' -Wall -funroll-loops'
 $CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
 


### PR DESCRIPTION
Without this compiler flag, the build fails with:

```
compiling ../../../../ext/charlock_holmes/ext.c
compiling ../../../../ext/charlock_holmes/transliterator.cpp
In file included from ../../../../ext/charlock_holmes/transliterator.cpp:5:
In file included from /usr/local/Cellar/icu4c/59.1/include/unicode/translit.h:25:
In file included from /usr/local/Cellar/icu4c/59.1/include/unicode/unistr.h:33:
/usr/local/Cellar/icu4c/59.1/include/unicode/char16ptr.h:90:19: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
    Char16Ptr() = delete;
                  ^
/usr/local/Cellar/icu4c/59.1/include/unicode/char16ptr.h:198:24: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
    ConstChar16Ptr() = delete;
                       ^
In file included from ../../../../ext/charlock_holmes/transliterator.cpp:5:
In file included from /usr/local/Cellar/icu4c/59.1/include/unicode/translit.h:25:
/usr/local/Cellar/icu4c/59.1/include/unicode/unistr.h:3025:7: error: delegating constructors are permitted only in C++11
      UnicodeString(ConstChar16Ptr(text)) {}
      ^~~~~~~~~~~~~
/usr/local/Cellar/icu4c/59.1/include/unicode/unistr.h:3087:7: error: delegating constructors are permitted only in C++11
      UnicodeString(ConstChar16Ptr(text), length) {}
      ^~~~~~~~~~~~~
/usr/local/Cellar/icu4c/59.1/include/unicode/unistr.h:3180:7: error: delegating constructors are permitted only in C++11
      UnicodeString(Char16Ptr(buffer), buffLength, buffCapacity) {}
      ^~~~~~~~~~~~~
```