### PR TITLE
Detect C++11 status

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -24,6 +24,8 @@ end
 dir_config 'icu'
 
 rubyopt = ENV.delete("RUBYOPT")
+
+icu4c = "/usr"
 # detect homebrew installs
 if !have_library 'icui18n'
   base = if !`which brew`.empty?
@@ -50,7 +52,13 @@ have_library 'z' or abort 'libz missing'
 have_library 'icuuc' or abort 'libicuuc missing'
 have_library 'icudata' or abort 'libicudata missing'
 
-$CXXFLAGS << ' -std=c++11'
+# icu4c might be built in C++11 mode, but it also might not have been
+icuconfig = `which icu-config`.chomp
+icuconfig = "#{icu4c}/bin/icu-config" if icuconfig.empty?
+if File.exist?(icuconfig) && `#{icuconfig} --cxxflags`.include?("c++11")
+  $CXXFLAGS << ' -std=c++11'
+end
+
 $CFLAGS << ' -Wall -funroll-loops'
 $CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
 


### PR DESCRIPTION
PR #116 breaks the build on systems with non-C++11 builds of icu4c. This affects a couple of environments:

1) Systems whose C++ compilers can't build C++11, and
2) Systems whose icu4c installations aren't built in C++11 mode. While my understanding is that icu4c 59 onward are always built as C++11, this isn't true of older versions.

This tries to detect the C++11 status by grabbing the `CXXFLAGS` from `icu-config`. I've confirmed that this works for me locally on a macOS system with icu4c 59, as well as an older Linux system with an older icu4c and a non-C++11 compatible compiler.

cc @brianmario, @dgraham 