### PR TITLE
extconf: Explicitly mark which icu-config to use when detecting Homebrew

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -25,6 +25,7 @@ dir_config 'icu'
 
 rubyopt = ENV.delete("RUBYOPT")
 
+icuconfig = ""
 icu4c = "/usr"
 # detect homebrew installs
 if !have_library 'icui18n'
@@ -37,6 +38,7 @@ if !have_library 'icui18n'
   if base and icu4c = Dir[File.join(base, 'icu4c/*')].sort.last
     $INCFLAGS << " -I#{icu4c}/include "
     $LDFLAGS  << " -L#{icu4c}/lib "
+    icuconfig = "#{icu4c}/bin/icu-config"
   end
 end
 
@@ -53,8 +55,7 @@ have_library 'icuuc' or abort 'libicuuc missing'
 have_library 'icudata' or abort 'libicudata missing'
 
 # icu4c might be built in C++11 mode, but it also might not have been
-icuconfig = `which icu-config`.chomp
-icuconfig = "#{icu4c}/bin/icu-config" if icuconfig.empty?
+icuconfig = `which icu-config`.chomp if icuconfig.empty?
 if File.exist?(icuconfig) && `#{icuconfig} --cxxflags`.include?("c++11")
   $CXXFLAGS << ' -std=c++11'
 end


### PR DESCRIPTION
This fixes an issue where the wrong icu-config could be chosen if `have_library 'icui18n'` fails, but the user still has an `icu-config` in their PATH.

I ran into this with a user who had Anaconda installed. Anaconda bundles a copy of icu4c, which is not located in one of the default lib paths and which therefore couldn't be found by `have_library 'icui18n'`; however, since its `icu-config` *was* in the user's `PATH`, it was picked up before Homebrew's icu-config here, causing build issues: https://github.com/brianmario/charlock_holmes/blob/master/ext/charlock_holmes/extconf.rb#L56

This fixes the issue by recording the path to `icu-config` when a Homebrew icu4c is selected, and only looking in the PATH in the case that we also accepted whatever icu4c `have_library` found.