### PR TITLE
Add version bounds to development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ vendor/
 *.bundle
 ext/charlock_holmes/dst
 *.a
+*.gem
 ext/charlock_holmes/src/file-*
 ext/charlock_holmes/src/mkmf.log

--- a/charlock_holmes.gemspec
+++ b/charlock_holmes.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new "charlock_holmes", CharlockHolmes::VERSION do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   # tests
-  s.add_development_dependency 'rake-compiler', ">= 0.7.5"
-  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rake-compiler', "~> 1.0"
+  s.add_development_dependency 'minitest', "~> 5.11"
   # benchmarks
-  s.add_development_dependency 'chardet'
+  s.add_development_dependency 'chardet', "~> 0.9"
 end


### PR DESCRIPTION
Silences warnings during `gem build`.

```
$ gem build charlock_holmes.gemspec
WARNING:  open-ended dependency on rake-compiler (>= 0.7.5, development) is not recommended
  if rake-compiler is semantically versioned, use:
    add_development_dependency 'rake-compiler', '~> 0.7', '>= 0.7.5'
WARNING:  open-ended dependency on minitest (>= 0, development) is not recommended
  if minitest is semantically versioned, use:
    add_development_dependency 'minitest', '~> 0'
WARNING:  open-ended dependency on chardet (>= 0, development) is not recommended
  if chardet is semantically versioned, use:
    add_development_dependency 'chardet', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```


This also prevents issues with a future Minitest 6 release.

```
$ bundle exec rake test
DEPRECATED: Use assert_nil if expecting nil from /Users/david/Code/charlock_holmes/test/encoding_detector_test.rb:147. This will fail in Minitest 6.
```