### PR TITLE
Make tests less brittle with newer ICU versions

### DIFF
--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -148,7 +148,12 @@ class EncodingDetectorTest < MiniTest::Test
       content = fixture(file).read
       guessed = @detector.detect content
 
-      assert_equal encoding, guessed[:encoding]
+      if encoding == nil
+        assert_nil guessed[:encoding]
+      else
+        assert_equal encoding, guessed[:encoding]
+      end
+
       assert_equal type, guessed[:type]
 
       if content.respond_to?(:force_encoding) && guessed[:type] == :text

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -24,7 +24,8 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_class_level_detect_all_method_accepts_encoding_hint
@@ -33,7 +34,8 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_has_detect_method
@@ -54,7 +56,8 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_detect_all_accepts_encoding_hint
@@ -63,7 +66,8 @@ class EncodingDetectorTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_strip_tags_flag

--- a/test/string_methods_test.rb
+++ b/test/string_methods_test.rb
@@ -26,7 +26,8 @@ class StringMethodsTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_detect_encodings_accepts_encoding_hint_param
@@ -37,7 +38,8 @@ class StringMethodsTest < MiniTest::Test
     assert detected_list.is_a? Array
 
     encoding_list = detected_list.map {|d| d[:encoding]}.sort
-    assert_equal ['ISO-8859-1', 'ISO-8859-2', 'UTF-8'], encoding_list
+    expected_list = ['ISO-8859-1', 'ISO-8859-2', 'UTF-8']
+    assert_equal expected_list, encoding_list & expected_list
   end
 
   def test_returns_a_ruby_compatible_encoding_name


### PR DESCRIPTION
This changes the list comparison tests for encoding detection to instead check that the expected encodings are within the list, not the exact list. In newer versions of ICU, some UTF-16 encodings were included in the results and breaking these tests. This makes sure we're compatible with that going forward.

This still isn't perfect, as encoding guesses can change in the future. But it should be less brittle than we are today.

This also includes a compatibility change readying us for Minitest 6.