### PR TITLE
README: Add whitespace to format Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Using Gem to install directly without Bundler:
 If you get a compile time error that looks like `error: delegating constructors are permitted only in C++11` or something else related to C++11, you need to set the `--with-cxxflags=-std=c++11` options
 
 Bundler:
+
     bundle config build.charlock_holmes --with-icu-dir=/path/to/installed/icu4c --with-cxxflags=-std=c++11
 
 Installing directly:
+
     gem install charlock_holmes -- --with-icu-dir=/path/to/installed/icu4c --with-cxxflags=-std=c++11
 
 ### Homebrew


### PR DESCRIPTION
This allows the commands to be rendered in monospace.

Hope this helps readability.