### PR TITLE
Make it possible to override -std=c++11 flag

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -34,7 +34,7 @@ pkg_config("icu-i18n")
 pkg_config("icu-io")
 pkg_config("icu-uc")
 
-$CXXFLAGS << ' -std=c++11'
+$CXXFLAGS << ' -std=c++11' unless $CXXFLAGS.include?("-std=")
 
 unless have_library 'icui18n' and have_header 'unicode/ucnv.h'
   STDERR.puts "\n\n"


### PR DESCRIPTION
On CentOS v6, which ships with g++ v4.4.7, the `-std=c++11` flag
doesn't work but `-std=c++0x` does. This change makes it possible to
install charlock_holmes via:

```
gem install charlock_holmes -- --with-cxxflags=-std=c++0x
```

Closes #152