### PR TITLE
Update supported Ruby versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ addons:
     - libicu-dev
 language: ruby
 rvm:
-  - 2.5
-  - 2.4
-  - 2.3
-  - 2.2
-  - 2.1
-  - 2.0.0
+  - 3.1
+  - 3.0
+  - 2.7
+  - 2.6
   - truffleruby-head


### PR DESCRIPTION
Everything including and before Ruby 2.6 is EOL. Add Ruby 2.7, 3.0,
and 3.1.