### PR TITLE
Remove -std=c++11 in CXXFLAGS

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -34,8 +34,6 @@ pkg_config("icu-i18n")
 pkg_config("icu-io")
 pkg_config("icu-uc")
 
-$CXXFLAGS << ' -std=c++11' unless $CXXFLAGS.include?("-std=")
-
 unless have_library 'icui18n' and have_header 'unicode/ucnv.h'
   STDERR.puts "\n\n"
   STDERR.puts "***************************************************************************************"


### PR DESCRIPTION
The default mode on a system should be fine in most cases. If a user needs to declare a special `-std` they can easily do it themselves by passing  `--with-cxxflags=-std=c++11`.

Fixes https://github.com/brianmario/charlock_holmes/issues/173