### PR TITLE
Re-introdude CXXFlags for darwin

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -24,6 +24,8 @@ if RbConfig::CONFIG["host_os"] =~ /darwin/
     # commandline options, but we need to set default ldflags and cpp flags
     # in case the user doesn't have pkg-config installed
     ENV['PKG_CONFIG_PATH'] ||= pkg_conf
+
+    $CXXFLAGS << ' -std=c++11' unless $CXXFLAGS.include?("-std=")
   rescue
   end
 end


### PR DESCRIPTION
These flags aren't set by default on this OS so to avoid the need to pass them into bundler / gem config we can set it for users.

This should fix the issue raised in #177 