### PR TITLE
Auto-detect C++ extensions needed to build

### DIFF
--- a/ext/charlock_holmes/common.h
+++ b/ext/charlock_holmes/common.h
@@ -38,4 +38,19 @@ static inline VALUE charlock_new_str2(const char *str)
 #endif
 }
 
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+extern void Init_charlock_holmes();
+extern void _init_charlock_encoding_detector();
+extern void _init_charlock_converter();
+extern void _init_charlock_transliterator();
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/ext/charlock_holmes/converter.c
+++ b/ext/charlock_holmes/converter.c
@@ -29,7 +29,7 @@ static VALUE rb_converter_convert(VALUE self, VALUE rb_txt, VALUE rb_src_enc, VA
 	if (status != U_BUFFER_OVERFLOW_ERROR) {
 		rb_raise(rb_eArgError, "%s", u_errorName(status));
 	}
-	out_buf = malloc(out_len);
+	out_buf = (char *) malloc(out_len);
 
 	// now do the actual conversion
 	status = U_ZERO_ERROR;

--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -352,7 +352,7 @@ static VALUE rb_encdec__alloc(VALUE klass)
 	UErrorCode status = U_ZERO_ERROR;
 	VALUE obj;
 
-	detector = calloc(1, sizeof(charlock_detector_t));
+	detector = (charlock_detector_t *) calloc(1, sizeof(charlock_detector_t));
 	obj = Data_Wrap_Struct(klass, NULL, rb_encdec__free, (void *)detector);
 
 	detector->csd = ucsdet_open(&status);

--- a/ext/charlock_holmes/ext.c
+++ b/ext/charlock_holmes/ext.c
@@ -1,9 +1,5 @@
 #include "common.h"
 
-extern void _init_charlock_encoding_detector();
-extern void _init_charlock_converter();
-extern void _init_charlock_transliterator();
-
 VALUE rb_mCharlockHolmes;
 
 void Init_charlock_holmes() {


### PR DESCRIPTION
Certain versions of clang (e.g. 15.0 on macOS) require manually enabling C++ extensions via `-std=c++<version>`, and ICU 75.1 needs C++17. Auto-detect the flags that are needed to build.

The default C++ version depends on the version of clang:

### clang 15.0.0 (macOS Sonoma)
 
```shell
# echo "" | clang++ -dM -E -x c++ - | grep __cplusplus
#define __cplusplus 199711L
```

On clang 18.1.8 (shipped with `archlinux/archlinux:base`):

```shell
# echo "" | clang++ -dM -E -x c++ - | grep __cplusplus
#define __cplusplus 201703L
```

|__cplusplus string|Version|
|--|--|
|199711L|C++98|
|201103L|C++11|
|201402L|C++14|
|201703L|C++17|
|202002L|C++20|

Relates to #172

Closes #177