### PR TITLE
Change data wrapping to use TypedData

### DIFF
--- a/ext/charlock_holmes/common.h
+++ b/ext/charlock_holmes/common.h
@@ -44,10 +44,10 @@ extern "C"
 {
 #endif
 
-extern void Init_charlock_holmes();
-extern void _init_charlock_encoding_detector();
-extern void _init_charlock_converter();
-extern void _init_charlock_transliterator();
+extern void Init_charlock_holmes(void);
+extern void _init_charlock_encoding_detector(void);
+extern void _init_charlock_converter(void);
+extern void _init_charlock_transliterator(void);
 
 #ifdef __cplusplus
 }

--- a/ext/charlock_holmes/converter.c
+++ b/ext/charlock_holmes/converter.c
@@ -20,7 +20,7 @@ static VALUE rb_converter_convert(VALUE self, VALUE rb_txt, VALUE rb_src_enc, VA
 	Check_Type(rb_dst_enc, T_STRING);
 
 	src_txt = RSTRING_PTR(rb_txt);
-	src_len = RSTRING_LEN(rb_txt);
+	src_len = (int32_t)RSTRING_LEN(rb_txt);
 	src_enc = RSTRING_PTR(rb_src_enc);
 	dst_enc = RSTRING_PTR(rb_dst_enc);
 
@@ -50,7 +50,7 @@ static VALUE rb_converter_convert(VALUE self, VALUE rb_txt, VALUE rb_src_enc, VA
 	return rb_out;
 }
 
-void _init_charlock_converter() {
+void _init_charlock_converter(void) {
 	rb_cConverter = rb_define_class_under(rb_mCharlockHolmes, "Converter", rb_cObject);
 
 	rb_define_singleton_method(rb_cConverter, "convert", rb_converter_convert, 3);

--- a/ext/charlock_holmes/ext.c
+++ b/ext/charlock_holmes/ext.c
@@ -2,7 +2,7 @@
 
 VALUE rb_mCharlockHolmes;
 
-void Init_charlock_holmes() {
+void Init_charlock_holmes(void) {
 	rb_mCharlockHolmes = rb_define_module("CharlockHolmes");
 
 	_init_charlock_encoding_detector();

--- a/ext/charlock_holmes/transliterator.cpp
+++ b/ext/charlock_holmes/transliterator.cpp
@@ -116,7 +116,7 @@ static VALUE rb_transliterator_transliterate(VALUE self, VALUE rb_txt, VALUE rb_
   return rb_out;
 }
 
-void _init_charlock_transliterator() {
+void _init_charlock_transliterator(void) {
 #ifdef HAVE_RUBY_ENCODING_H
   rb_eEncodingCompatibilityError = rb_const_get(rb_cEncoding, rb_intern("CompatibilityError"));
 #endif


### PR DESCRIPTION
The old Data_* API is deprecated, so this changes us to use the TypedData APIs. Also cleans up some compiler warnings