### PR TITLE
Add space to play nicely with --with-cppflags parameters

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -56,7 +56,7 @@ SRC
 
 # Pass -x c++ to force gcc to compile the test program
 # as C++ (as it will end in .c by default).
-compile_options = +"-x c++"
+compile_options = +" -x c++"
 
 icu_requires_version_flag = checking_for("icu that requires explicit C++ version flag") do
   !try_compile(minimal_program, compile_options)


### PR DESCRIPTION
Attempting to build charlock_holmes with `--with-cppflags` will fail unless you append a space at the end. For example, to build with XCode 16.0 and macOS SDK 15.0, for some reason I had to manually add the C++ include path with a trailing space:

```
gem install charlock_holmes -- --enable-static --with-cppflags='-I/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/c++/v1 '
```