### PR TITLE
Fix one-time memory leak of encoding_list

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -350,6 +350,7 @@ static VALUE rb_get_supported_encodings(VALUE klass)
 
 		rb_iv_set(klass, "encoding_list", rb_encoding_list);
 		ucsdet_close(csd);
+		uenum_close(encoding_list);
 	}
 
 	return rb_encoding_list;


### PR DESCRIPTION
We memoize this result after calculating it, and the amount of memory is tiny, so this shouldn't cause any harm. Still it's good to fix so that tools can find more serious leaks.

This was found by compiling ruby with ASAN/LSAN and running:

    ASAN_OPTIONS="detect_leaks=1" RUBY_FREE_AT_EXIT=1 bundle exec rake
