### PR TITLE
Revert "return `ruby_encoding` & `encoding` fields for binary data"

### DIFF
--- a/ext/charlock_holmes/encoding_detector.c
+++ b/ext/charlock_holmes/encoding_detector.c
@@ -72,8 +72,6 @@ static VALUE rb_encdec_binarymatch(void) {
 	rb_match = rb_hash_new();
 
 	rb_hash_aset(rb_match, ID2SYM(rb_intern("type")), ID2SYM(rb_intern("binary")));
-	rb_hash_aset(rb_match, ID2SYM(rb_intern("encoding")), charlock_new_str2("BINARY"));
-	rb_hash_aset(rb_match, ID2SYM(rb_intern("ruby_encoding")), charlock_new_str2("ASCII-8BIT"));
 	rb_hash_aset(rb_match, ID2SYM(rb_intern("confidence")), INT2NUM(100));
 
 	return rb_match;

--- a/test/encoding_detector_test.rb
+++ b/test/encoding_detector_test.rb
@@ -107,10 +107,6 @@ class EncodingDetectorTest < Minitest::Test
     detected = @detector.detect not_compat_txt
     assert_equal 'ISO-2022-KR', detected[:encoding]
     assert_equal 'binary', detected[:ruby_encoding]
-
-    detected = @detector.detect "\0\0"
-    assert_equal 'BINARY', detected[:encoding]
-    assert_equal 'ASCII-8BIT', detected[:ruby_encoding]
   end
 
   def test_is_binary
@@ -136,13 +132,13 @@ class EncodingDetectorTest < Minitest::Test
     ['utf16be.html',              'UTF-16BE',   :text],
     ['utf32le.html',              'UTF-32LE',   :text],
     ['utf32be.html',              'UTF-32BE',   :text],
-    ['hello_world',               'BINARY',     :binary],
-    ['octocat.png',               'BINARY',     :binary],
-    ['octocat.jpg',               'BINARY',     :binary],
-    ['octocat.psd',               'BINARY',     :binary],
-    ['octocat.gif',               'BINARY',     :binary],
-    ['octocat.ai',                'BINARY',     :binary],
-    ['foo.pdf',                   'BINARY',     :binary],
+    ['hello_world',               nil,          :binary],
+    ['octocat.png',               nil,          :binary],
+    ['octocat.jpg',               nil,          :binary],
+    ['octocat.psd',               nil,          :binary],
+    ['octocat.gif',               nil,          :binary],
+    ['octocat.ai',                nil,          :binary],
+    ['foo.pdf',                   nil,          :binary],
   ]
 
   def test_detection_works_as_expected


### PR DESCRIPTION
Reverts brianmario/charlock_holmes#113

I don't think we should have done this. Although `:ruby_encoding=>"ASCII-8BIT"` makes sense, the `:encoding` field is supposed to return the ICU encoding name and `"BINARY"` is not a valid ICU encoding (which makes sense, you it's not really a format).

Since there isn't a correct value there, having no value or nil is a better sentinel.