### PR TITLE
Fix native extension build on M1 macOS (Ruby 3+) by adjusting compiler flags

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -12,14 +12,21 @@ end
 # ICU dependency
 #
 
+# If on Apple Silicon (M1, host_cpu "arm64") and Ruby version is 3.0.0 or greater,
+# then force the C++ compiler to clang++.
+FORCE_COMPATIBILITY_APPLE_M1_RUBY_3 = (RbConfig::CONFIG['host_cpu'] == 'arm64' && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')) || false
+if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
+  RbConfig::CONFIG["CXX"] = "/usr/bin/clang++"
+end
+
 ldflags = cppflags = nil
 
 if RbConfig::CONFIG["host_os"] =~ /darwin/
   begin
     brew_prefix = `brew --prefix icu4c`.chomp
-    ldflags   = "#{brew_prefix}/lib"
-    cppflags  = "#{brew_prefix}/include"
-    pkg_conf  = "#{brew_prefix}/lib/pkgconfig"
+    ldflags = "#{brew_prefix}/lib"
+    cppflags = "#{brew_prefix}/include"
+    pkg_conf = "#{brew_prefix}/lib/pkgconfig"
     # pkg_config should be less error prone than parsing compiler
     # commandline options, but we need to set default ldflags and cpp flags
     # in case the user doesn't have pkg-config installed
@@ -67,8 +74,11 @@ if icu_requires_version_flag
     checking_for("icu that compiles with #{std} standard") do
       flags = compile_options + " -std=#{std}"
       if try_compile(minimal_program, flags)
-        $CPPFLAGS << flags
-
+        if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
+          $CXXFLAGS << " " << flags
+        else
+          $CPPFLAGS << flags
+        end
         true
       end
     end
@@ -137,5 +147,8 @@ if static_p
 
   substitute_static_libs(%w[icu-i18n icu-io icu-uc])
 end
+
+# Remove stray "-x c++" flag that may have been appended.
+$CPPFLAGS.gsub!(/-x\s*c\+\+/, '') if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
 
 create_makefile 'charlock_holmes/charlock_holmes'

--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -15,9 +15,6 @@ end
 # If on Apple Silicon (M1, host_cpu "arm64") and Ruby version is 3.0.0 or greater,
 # then force the C++ compiler to clang++.
 FORCE_COMPATIBILITY_APPLE_M1_RUBY_3 = (RbConfig::CONFIG['host_cpu'] == 'arm64' && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')) || false
-if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
-  RbConfig::CONFIG["CXX"] = "/usr/bin/clang++"
-end
 
 ldflags = cppflags = nil
 
@@ -63,7 +60,7 @@ SRC
 
 # Pass -x c++ to force gcc to compile the test program
 # as C++ (as it will end in .c by default).
-compile_options = +"-x c++"
+compile_options = +"-x c++" unless FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
 
 icu_requires_version_flag = checking_for("icu that requires explicit C++ version flag") do
   !try_compile(minimal_program, compile_options)
@@ -74,11 +71,7 @@ if icu_requires_version_flag
     checking_for("icu that compiles with #{std} standard") do
       flags = compile_options + " -std=#{std}"
       if try_compile(minimal_program, flags)
-        if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
-          $CXXFLAGS << " " << flags
-        else
-          $CPPFLAGS << flags
-        end
+        $CFLAGS << flags
         true
       end
     end
@@ -147,8 +140,5 @@ if static_p
 
   substitute_static_libs(%w[icu-i18n icu-io icu-uc])
 end
-
-# Remove stray "-x c++" flag that may have been appended.
-$CPPFLAGS.gsub!(/-x\s*c\+\+/, '') if FORCE_COMPATIBILITY_APPLE_M1_RUBY_3
 
 create_makefile 'charlock_holmes/charlock_holmes'

--- a/lib/charlock_holmes/version.rb
+++ b/lib/charlock_holmes/version.rb
@@ -1,3 +1,3 @@
 module CharlockHolmes
-  VERSION = "0.7.8"
+  VERSION = "0.7.9"
 end


### PR DESCRIPTION
This change addresses a build failure on M1 MacBooks (macOS 15.3, build 24D60) when compiling the charlock_holmes gem with Ruby 3+. The problem was caused by an explicit hardcoded flag (-x c++) in the **_ext/charlock_holmes/extconf.rb_** file, which caused the C compiler to receive a stray "C++" argument.

```
# ext/charlock_holmes/extconf.rb 
compile_options = +"-x c++"
```

After some troubleshooting I've come up with fixes:
* Force the use of /usr/bin/clang++ instead of the default g++ on Apple Silicon (arm64) with Ruby ≥ 3.0.0.
* Append the ICU C++ standard flag to $CXXFLAGS (not $CPPFLAGS) to prevent C files from receiving C++ flags.
* Strip stray -x c++ from $CPPFLAGS for affected systems.

Tested on macOS 15.3 M1 with Ruby 3.0.2 and 3.3.5 using a custom script for encoding detection/conversion.

A test script was used to verify core functionality (encoding detection and conversion) with different sample strings. 

For example:
For the short sample `"Caf\xe9".force_encoding("ISO-8859-1")`, the detector returns low confidence (15) and defaults to UTF-8 (this is expected with such a short and ambiguous string).
For a longer sample such as
`"Caf\xe9 au lait, d\xe9j\xe0 vu, cr\xe8me brûl\xe9e, voilà, à la mode".force_encoding("ISO-8859-1")`, the detector correctly identifies the encoding as ISO-8859-1 with higher confidence (41) and the conversion produces a reasonably correct UTF-8 string.

I've shared the full test script source and output details below.

Error log I had before fix: <details>
```
% gem install charlock_holmes-0.7.9.gem -- \
  --with-icu-dir="$(brew --prefix icu4c)" \
  --with-cxx=/usr/bin/clang++ \
  --with-cxxflags="-std=c++17"
  
Building native extensions. This could take a while...
ERROR:  Error installing charlock_holmes-0.7.9.gem:
        ERROR: Failed to build gem native extension.
checking for -licui18n... yes
checking for unicode/ucnv.h... yes
checking for -lz... yes
checking for -licuuc... yes
checking for -licudata... yes
checking for icu that requires explicit C++ version flag... yes
checking for icu that compiles with c++20 standard... yes
Static linking is disabled.
creating Makefile
clang: error: no such file or directory: 'c++'
make: *** [converter.o] Error 1
```
Because of the hardcoded **c++** flag in extconf.rb  **--with-cxx** flags have been ignored.
I tried maybe everything to help the compiler recognize the C++ compiler installed in the system but always got the same error.
</details>

Test script source: <details> 
```
#!/usr/bin/env ruby
require 'charlock_holmes'

puts "Testing charlock_holmes gem..."

# Sample string encoded in ISO-8859-1 (Latin-1)
sample_text = "Caf\xe9".force_encoding("ISO-8859-1")
puts "Original string: #{sample_text} (encoding: #{sample_text.encoding})"

# Detect the encoding
detection = CharlockHolmes::EncodingDetector.detect(sample_text)
if detection
  puts "Detected encoding: #{detection[:encoding]}"
  puts "Detection confidence: #{detection[:confidence]}"
else
  puts "Encoding detection failed."
  exit(1)
end

# Convert the string to UTF-8
begin
  converted = CharlockHolmes::Converter.convert(sample_text, detection[:encoding], "UTF-8")
  puts "Converted string: #{converted} (encoding: #{converted.encoding})"
rescue => e
  puts "Error during conversion: #{e}"
end

detection = CharlockHolmes::EncodingDetector.detect(sample_text)
if detection
  puts "Detected encoding: #{detection[:encoding]}"
  puts "Detection confidence: #{detection[:confidence]}"
else
  puts "No encoding detected."
end

sample_text = "Caf\xe9 au lait, d\xe9j\xe0 vu, cr\xe8me brûl\xe9e".force_encoding("ISO-8859-1")
puts "Original string: #{sample_text} (encoding: #{sample_text.encoding})"
# Convert the string to UTF-8 based on the detection.
begin
  converted = CharlockHolmes::Converter.convert(sample_text, detection[:encoding], "UTF-8")
  puts "Converted string: #{converted} (encoding: #{converted.encoding})"
rescue => e
  puts "Conversion error: #{e}"
end

# Create a longer, less ambiguous ISO-8859-1 sample
sample_text = "Caf\xe9 au lait, d\xe9j\xe0 vu, cr\xe8me brûl\xe9e, voilà, à la mode".force_encoding("ISO-8859-1")
puts "Original string: #{sample_text} (encoding: #{sample_text.encoding})"

detection = CharlockHolmes::EncodingDetector.detect(sample_text)
if detection
  puts "Detected encoding: #{detection[:encoding]}"
  puts "Detection confidence: #{detection[:confidence]}"
else
  puts "No encoding detected."
end

converted = CharlockHolmes::Converter.convert(sample_text, detection[:encoding], "UTF-8")
puts "Converted string: #{converted} (encoding: #{converted.encoding})"
```
</details>

Test script output: <details>
```
Testing charlock_holmes gem...
Original string: Caf� (encoding: ISO-8859-1)
Detected encoding: UTF-8
Detection confidence: 15
Converted string: Caf� (encoding: UTF-8)
Detected encoding: UTF-8
Detection confidence: 15
Original string: Caf� au lait, d�j� vu, cr�me brûl�e (encoding: ISO-8859-1)
Converted string: Caf� au lait, d�j� vu, cr�me brûl�e (encoding: UTF-8)
Original string: Caf� au lait, d�j� vu, cr�me brûl�e, voilà, à la mode (encoding: ISO-8859-1)
Detected encoding: ISO-8859-1
Detection confidence: 41
Converted string: Café au lait, déjà vu, crème brÃ»lée, voilÃ , Ã  la mode (encoding: UTF-8)
```
 </details>
 
 Thank you for your attention! 
