### PR TITLE
Fix ICU detection to use actual installed version on macOS

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -16,7 +16,20 @@ ldflags = cppflags = nil
 
 if RbConfig::CONFIG["host_os"] =~ /darwin/
   begin
-    brew_prefix = `brew --prefix icu4c`.chomp
+    # Find the actual installed icu4c version
+    # Get all installed icu4c versions (including versioned ones like icu4c@77, icu4c@78)
+    installed_icus = `brew list --formula`.split("\n").select { |formula| formula.start_with?('icu4c') }
+
+    if installed_icus.any?
+      # Sort to get the latest version (icu4c@78 > icu4c@77 > icu4c)
+      # Versioned packages will sort after the base package due to '@' character
+      installed_icu = installed_icus.sort.last
+      brew_prefix = `brew --prefix #{installed_icu}`.chomp
+    else
+      # Fallback to default icu4c if no versioned package found
+      brew_prefix = `brew --prefix icu4c`.chomp
+    end
+
     ldflags   = "#{brew_prefix}/lib"
     cppflags  = "#{brew_prefix}/include"
     pkg_conf  = "#{brew_prefix}/lib/pkgconfig"


### PR DESCRIPTION
The previous implementation used `brew --prefix icu4c` which returns the path where the latest icu4c package would be installed, not necessarily where an installed version actually exists.

If a user has an older versioned package installed (e.g., icu4c@77), the path `/opt/homebrew/opt/icu4c` would not exist, causing the build to fail.

This change:

- Detects all installed icu4c packages (including versioned ones)
- Selects the latest installed version
- Uses that version's actual installation path

This ensures the build works correctly when users have versioned ICU packages installed via Homebrew.