### PR TITLE
Fix C++ standard probe to match actual build environment (ICU 76+)

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -67,9 +67,15 @@ minimal_program = <<~SRC
   int main() { return 0; }
 SRC
 
-# Pass -x c++ to force gcc to compile the test program
-# as C++ (as it will end in .c by default).
+# Pass -x c++ to force gcc to compile the test program as C++ (try_compile
+# writes the source to a .c file). Also mirror the -std= flag baked into
+# RbConfig's CXX (e.g. `g++ -std=gnu++11` on most Ruby builds) so the probe
+# matches what the real .cpp build will use. Without this, modern gcc's
+# default for -x c++ is newer than g++ -std=gnu++11, so the probe passes
+# while the real build still fails against ICU 76+ headers.
+cxx_std_flag = RbConfig::CONFIG["CXX"].to_s[/-std=\S+/]
 compile_options = +"-x c++"
+compile_options << " #{cxx_std_flag}" if cxx_std_flag
 
 icu_requires_version_flag = checking_for("icu that requires explicit C++ version flag") do
   !try_compile(minimal_program, compile_options)
@@ -78,10 +84,10 @@ end
 if icu_requires_version_flag
   abort "Cannot compile icu with your compiler: recent versions require C++17 support." unless %w[c++20 c++17 c++11 c++0x].any? do |std|
     checking_for("icu that compiles with #{std} standard") do
-      flags = compile_options + " -std=#{std}"
-      if try_compile(minimal_program, flags)
-        $CPPFLAGS << flags
-
+      if try_compile(minimal_program, "-x c++ -std=#{std}")
+        # Append to CXXFLAGS so the flag only applies to .cpp compilation.
+        # gcc/clang let a later -std= override the one baked into CXX.
+        $CXXFLAGS << " -std=#{std}"
         true
       end
     end


### PR DESCRIPTION
## Summary

Fixes #203 — `charlock_holmes` fails to build against ICU 76+ on systems where the compiler's "raw" C++ default is newer than `g++ -std=gnu++11`.

The C++-standard auto-detect added in e6bf7345 probes with `try_compile` plus `-x c++`, which on modern GCC (e.g. GCC 15 on Fedora 44) defaults to a C++17+ standard. The real `.cpp` build, however, uses `RbConfig::CONFIG["CXX"]`, which on most Ruby builds is `g++ -std=gnu++11`. The probe therefore silently passes while `transliterator.cpp` still fails with hundreds of errors out of ICU's headers (`std::u16string_view`, `std::enable_if_t`, `auto` non-type template parameters, etc.).

This PR makes the probe represent reality by:

1. Mirroring the `-std=` flag baked into `CXX` into the `try_compile` invocation, so the probe fails exactly when the real build would fail.
2. When a working standard is found, appending `-std=...` to `$CXXFLAGS` (so it only affects `.cpp` compilation) instead of `$CPPFLAGS` (which also leaked `-x c++` and `-std=c++17` onto the `.c` compile lines).

A later `-std=` overrides the one baked into `CXX` on both gcc and clang, so this cleanly upgrades the standard for ICU's headers without disturbing the rest of the build.

## Test plan

Reproduced the failure on the affected environment (Fedora 44, GCC 15, ICU 77.1, Ruby 4.0.3) and verified:

- [x] Before the fix: `checking for icu that requires explicit C++ version flag... no` followed by `make` failing in `transliterator.cpp` with `std::u16string_view`, `enable_if_t`, and `auto` template parameter errors.
- [x] After the fix: `checking for icu that requires explicit C++ version flag... yes` → `checking for icu that compiles with c++20 standard... yes`, and `rake compile test` passes (27 runs, 120 assertions, 0 failures, 0 errors).
- [x] Generated Makefile now has `CXXFLAGS = ... -std=c++20 ...` (only on the C++ rule) — the `.c` files no longer get the C++ standard flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)