### PR TITLE
Remove outdated `make` check in extconf

### DIFF
--- a/ext/charlock_holmes/extconf.rb
+++ b/ext/charlock_holmes/extconf.rb
@@ -1,13 +1,5 @@
 require 'mkmf'
 
-if `which make`.strip.empty?
-  STDERR.puts "\n\n"
-  STDERR.puts "***************************************************************************************"
-  STDERR.puts "*************** make required (apt-get install make build-essential) =( ***************"
-  STDERR.puts "***************************************************************************************"
-  exit(1)
-end
-
 ##
 # ICU dependency
 #


### PR DESCRIPTION
This was introduced in https://github.com/brianmario/charlock_holmes/commit/1216f79502883975005cc9e8d15842d7514c2c34 because at the time the extconf would directly invoke `make`, but that's no longer the case.

By checking `make` specifically the extconf may break when it would have succeeded because mkmf/rubygems look for `with_config("make-prog", ENV["MAKE"] || "make")`.